### PR TITLE
adding browser and device check

### DIFF
--- a/Web/packages/check/src/CheckerApp.tsx
+++ b/Web/packages/check/src/CheckerApp.tsx
@@ -5,10 +5,15 @@ import { useChecker } from "./hooks/useChecker";
 
 export type CheckerAppProps = {
   check: () => boolean;
+  checkBrowser: () => boolean;
   onOpenApp: () => void;
 };
 
-export const CheckerApp: VFC<CheckerAppProps> = ({ check, onOpenApp }) => {
-  const status = useChecker(check);
+export const CheckerApp: VFC<CheckerAppProps> = ({
+  check,
+  checkBrowser,
+  onOpenApp,
+}) => {
+  const status = useChecker(check, checkBrowser);
   return <CheckResult status={status} onOpenApp={onOpenApp} />;
 };

--- a/Web/packages/check/src/check.test.ts
+++ b/Web/packages/check/src/check.test.ts
@@ -1,0 +1,52 @@
+import { checkBrowser } from "./check";
+
+describe("checkBrowser", () => {
+  test("test Safari on mac", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36",
+        false
+      )
+    ).toBe(false);
+  });
+  test("test Chrome on iphone", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/95.0.4638.50 Mobile/15E148 Safari/604.1",
+        true
+      )
+    ).toBe(false);
+  });
+  test("test FireFox on iphone", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/39.0 Mobile/15E148 Safari/605.1.15",
+        true
+      )
+    ).toBe(false);
+  });
+  test("test Safari on iPad", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36",
+        true
+      )
+    ).toBe(true);
+  });
+  test("test Safari on iPhone", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Mobile/15E148 Safari/604.1",
+        true
+      )
+    ).toBe(true);
+  });
+  test("test Chrome on iPad", () => {
+    expect(
+      checkBrowser(
+        "Mozilla/5.0 (iPad; CPU OS 15_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/96.0.4664.36 Mobile/15E148 Safari/604.1",
+        true
+      )
+    ).toBe(false);
+  });
+});

--- a/Web/packages/check/src/check.ts
+++ b/Web/packages/check/src/check.ts
@@ -1,3 +1,19 @@
 export function check(): boolean {
   return !!document.getElementById("svadilfari-content-root");
 }
+
+export function checkBrowser(ua: string, isTouchDevice: boolean): boolean {
+  if (!isTouchDevice) {
+    return false;
+  }
+  const iphoneRegex =
+    /Mozilla\/5\.0 \(iPhone; CPU iPhone OS [\d_]+ like Mac OS X\) AppleWebKit\/[\d\.]+ \(KHTML, like Gecko\) Version\/[\d\.]+ Mobile\/[\dA-Z]+ Safari\/[\d\.]+/;
+
+  const ipadRegex =
+    /Mozilla\/5\.0 \(Macintosh; Intel Mac OS X [\d_]+\) AppleWebKit\/[\d\.]+ \(KHTML, like Gecko\) Chrome\/[\d\.]+ Safari\/[\d\.]+/;
+  if (iphoneRegex.test(ua) || ipadRegex.test(ua)) {
+    return true;
+  }
+
+  return false;
+}

--- a/Web/packages/check/src/components/CheckResult.stories.tsx
+++ b/Web/packages/check/src/components/CheckResult.stories.tsx
@@ -22,3 +22,6 @@ Active.args = { status: "ACTIVE" };
 
 export const Inactive = Template.bind({});
 Inactive.args = { status: "INACTIVE" };
+
+export const Unsupported = Template.bind({});
+Unsupported.args = { status: "UNSUPPORTED" };

--- a/Web/packages/check/src/components/CheckResult.tsx
+++ b/Web/packages/check/src/components/CheckResult.tsx
@@ -13,7 +13,7 @@ import React, { VFC } from "react";
 import { t } from "react-i18nify";
 
 export type CheckResultProps = {
-  status: "ACTIVE" | "INACTIVE" | null;
+  status: "ACTIVE" | "INACTIVE" | "UNSUPPORTED" | null;
   onOpenApp: () => void;
 };
 
@@ -50,6 +50,27 @@ export const CheckResult: VFC<CheckResultProps> = ({ status, onOpenApp }) => {
           <Button colorScheme="green" onClick={onOpenApp}>
             {t("check_result.app_link")}
           </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (status === "UNSUPPORTED") {
+    return (
+      <Alert
+        status="error"
+        variant="subtle"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        textAlign="center"
+        height="100%"
+      >
+        <AlertIcon boxSize="40px" mr={0} />
+        <AlertTitle mt={4} mb={1} fontSize="lg">
+          {t("check_result.unsupported.title")}
+        </AlertTitle>
+        <AlertDescription maxWidth="sm">
+          {t("check_result.unsupported.description")}
         </AlertDescription>
       </Alert>
     );

--- a/Web/packages/check/src/hooks/useChecker.ts
+++ b/Web/packages/check/src/hooks/useChecker.ts
@@ -1,6 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 
-export function useChecker(check: () => boolean): "ACTIVE" | "INACTIVE" | null {
+export function useChecker(
+  check: () => boolean,
+  checkBrowser: () => boolean
+): "ACTIVE" | "INACTIVE" | "UNSUPPORTED" | null {
   const [enabled, setEnabled] = useState<boolean | null>(null);
   useEffect(() => {
     let subscribed = true;
@@ -27,6 +30,15 @@ export function useChecker(check: () => boolean): "ACTIVE" | "INACTIVE" | null {
       subscribed = false;
     };
   }, [check]);
+
+  const isSupported = useMemo(() => {
+    return checkBrowser();
+  }, [checkBrowser]);
+  console.log({ isSupported });
+  if (!isSupported) {
+    return "UNSUPPORTED";
+  }
+
   if (enabled === null) {
     return null;
   }

--- a/Web/packages/check/src/i18n.ts
+++ b/Web/packages/check/src/i18n.ts
@@ -16,6 +16,11 @@ export function i18n(): void {
           still_having_problem: "Still having a problem?",
           contact_us: "Contact Us",
         },
+        unsupported: {
+          title: "Svadilfari is NOT Supported on this browser",
+          description:
+            "This app is only supported on iPhones/iPads Safari browser",
+        },
       },
     },
     ja: {
@@ -31,6 +36,10 @@ export function i18n(): void {
           description: "チュートリアルを完了して機能拡張を有効化してください",
           still_having_problem: "解決しませんか？",
           contact_us: "問い合わせる",
+        },
+        unsupported: {
+          title: "Svadilfariはこのブラウザ上では使用できません！",
+          description: "iPhone及びiPadのSafariのみサポートしています！",
         },
       },
     },

--- a/Web/packages/check/src/main.tsx
+++ b/Web/packages/check/src/main.tsx
@@ -2,10 +2,12 @@ import { ChakraProvider } from "@chakra-ui/react";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import { check } from "./check";
+import { check, checkBrowser } from "./check";
 import { CheckerApp } from "./CheckerApp";
 import { i18n } from "./i18n";
 import "./index.css";
+
+const isTouchDevice = "ontouchstart" in window || navigator.maxTouchPoints > 0;
 
 i18n();
 ReactDOM.render(
@@ -14,6 +16,9 @@ ReactDOM.render(
       <CheckerApp
         check={check}
         onOpenApp={() => window.open("svadilfari://")}
+        checkBrowser={() => {
+          return checkBrowser(navigator.userAgent, isTouchDevice);
+        }}
       />
     </ChakraProvider>
   </React.StrictMode>,


### PR DESCRIPTION
https://github.com/shumbo/Svadilfari/issues/12
I was able to add a check for the browser and device using the extension. I made it so that it shows an error screen if the device using the extension is not an iPhone or an iPad, or using a browser other than Safari. Do you mind checking my work and see if you like it? Thanks!